### PR TITLE
Added an option to only allow panning the UINavigationBar of the root view controller

### DIFF
--- a/MFSideMenuDemo/MFAppDelegate.m
+++ b/MFSideMenuDemo/MFAppDelegate.m
@@ -32,7 +32,7 @@
     
     SideMenuViewController *sideMenuViewController = [[SideMenuViewController alloc] init];
     
-    MenuOptions options = MenuButtonEnabled|BackButtonEnabled;
+    MenuOptions options = MenuButtonEnabled|BackButtonEnabled|OnlyPanRootNavbar;
     // make sure to display the navigation controller before calling this
     [MFSideMenuManager configureWithNavigationController:navigationController 
                                       sideMenuController:sideMenuViewController

--- a/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.h
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.h
@@ -15,7 +15,8 @@ typedef enum {
 
 typedef enum {
     MenuButtonEnabled = 1 << 0, // enable the 'menu' UIBarButtonItem
-    BackButtonEnabled = 1 << 1 // enable the 'back' UIBarButtonItem
+    BackButtonEnabled = 1 << 1,  // enable the 'back' UIBarButtonItem
+    OnlyPanRootNavbar = 1 << 2  // only pan the root UINavigationBar
 } MenuOptions;
 
 
@@ -43,5 +44,5 @@ typedef enum {
 
 + (BOOL) menuButtonEnabled;
 + (BOOL) backButtonEnabled;
-
++ (BOOL) onlyPanRootNavbar;
 @end

--- a/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
@@ -26,7 +26,7 @@
 
 + (void) configureWithNavigationController:(UINavigationController *)controller 
                         sideMenuController:(id)menuController {
-    MenuOptions options = MenuButtonEnabled|BackButtonEnabled;
+    MenuOptions options = MenuButtonEnabled|BackButtonEnabled|OnlyPanRootNavbar;
     
     [MFSideMenuManager configureWithNavigationController:controller
                                       sideMenuController:menuController
@@ -108,6 +108,10 @@
 
 + (BOOL) backButtonEnabled {
     return (([MFSideMenuManager sharedManager].options & BackButtonEnabled) == BackButtonEnabled);
+}
+
++ (BOOL) onlyPanRootNavbar {
+    return (([MFSideMenuManager sharedManager].options & OnlyPanRootNavbar) == OnlyPanRootNavbar);
 }
 
 - (void) drawNavigationControllerShadowPath {    
@@ -314,8 +318,14 @@
 
 - (void) navigationBarPanned:(id)sender {
     if(self.navigationController.menuState != MFSideMenuStateHidden) return;
-    
-    [self handleNavigationBarPan:sender];
+
+    if([MFSideMenuManager onlyPanRootNavbar]) {
+        if(self.navigationController.visibleViewController == [self.navigationController.viewControllers objectAtIndex:0]) {
+            [self handleNavigationBarPan:sender];
+        }
+    } else {
+        [self handleNavigationBarPan:sender];
+    }
 }
 
 


### PR DESCRIPTION
If you push a view controller (or several) you can still pan the navbar to show the menu.  I saw this as a bug initially, thinking that you should only be able to pan the root view controller, and subsequent VCs should just have the regular "back" button but no panning.

In the end, I made it an option.
