### PR TITLE
Always allow pan gesture on navigation controller's view

### DIFF
--- a/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
@@ -133,8 +133,7 @@
        self.navigationController.menuState != MFSideMenuStateHidden) return YES;
     
     if([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
-        if([gestureRecognizer.view isEqual:self.navigationController.view] && 
-           self.navigationController.menuState != MFSideMenuStateHidden) return YES;
+        if([gestureRecognizer.view isEqual:self.navigationController.view]) return YES;
         
         if([gestureRecognizer.view isEqual:self.navigationController.navigationBar] && 
            self.navigationController.menuState == MFSideMenuStateHidden) return YES;
@@ -306,9 +305,7 @@
 	}
 }
 
-- (void) navigationControllerPanned:(id)sender {
-    if(self.navigationController.menuState == MFSideMenuStateHidden) return;
-    
+- (void) navigationControllerPanned:(id)sender {    
     [self handleNavigationBarPan:sender];
 }
 


### PR DESCRIPTION
Facebook allows the user to perform a pan gesture in the navigation controller's view to reveal the side menu. This pull request makes **MFSideMenu** conform to this behavior.
