### PR TITLE
Add CocoaPods spec

### DIFF
--- a/MFSideMenu.podspec
+++ b/MFSideMenu.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+  s.name     = 'MFSideMenu'
+  s.version  = '0.2'
+  s.license  = 'BSD'
+  s.summary  = 'Facebook-like side menu for iOS.'
+  s.homepage = 'https://github.com/mikefrederick/MFSideMenu'
+  s.author   = { 'Michael Frederick' => 'mike@viamike.com' }
+  s.source   = { :git => 'https://github.com/mikefrederick/MFSideMenu.git', :tag => '0.2' }
+  s.platform = :ios
+  s.source_files = 'MFSideMenuDemo/MFSideMenu/*.{h,m}'
+  s.resources = 'MFSideMenuDemo/MFSideMenu/*.png'
+  s.frameworks   = 'QuartzCore'
+end

--- a/MFSideMenuDemo.xcodeproj/project.pbxproj
+++ b/MFSideMenuDemo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		275F15B41517F0B90052A240 /* SideMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 275F15B31517F0B90052A240 /* SideMenuViewController.m */; };
 		275F15BA1517F5770052A240 /* back-arrow.png in Resources */ = {isa = PBXBuildFile; fileRef = 275F15B91517F5770052A240 /* back-arrow.png */; };
 		275F15BC1517F7A20052A240 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 275F15BB1517F7A20052A240 /* QuartzCore.framework */; };
+		643499E0161205B6009340E7 /* MFSideMenu.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 643499DF161205B6009340E7 /* MFSideMenu.podspec */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -51,6 +52,7 @@
 		275F15B31517F0B90052A240 /* SideMenuViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SideMenuViewController.m; sourceTree = "<group>"; };
 		275F15B91517F5770052A240 /* back-arrow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "back-arrow.png"; sourceTree = "<group>"; };
 		275F15BB1517F7A20052A240 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		643499DF161205B6009340E7 /* MFSideMenu.podspec */ = {isa = PBXFileReference; explicitFileType = text; fileEncoding = 4; path = MFSideMenu.podspec; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -74,6 +76,7 @@
 				275F158D1517E9B80052A240 /* MFSideMenuDemo */,
 				275F15861517E9B80052A240 /* Frameworks */,
 				275F15841517E9B80052A240 /* Products */,
+				643499DF161205B6009340E7 /* MFSideMenu.podspec */,
 			);
 			sourceTree = "<group>";
 		};
@@ -197,6 +200,7 @@
 				275F15B01517F0380052A240 /* menu-icon.png in Resources */,
 				275F15B11517F0380052A240 /* menu-icon@2x.png in Resources */,
 				275F15BA1517F5770052A240 /* back-arrow.png in Resources */,
+				643499E0161205B6009340E7 /* MFSideMenu.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
It is a good idea to version the CocoaPods spec in the source repository and use `pod push origin MFSideMenu.podspec` to publish the updated pod after creating a new tag.
