### PR TITLE
Do not invoke orientSideMenuFromStatusBar

### DIFF
--- a/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenuManager.m
@@ -75,9 +75,7 @@
     [tapRecognizer release];
     
     [controller.view.superview insertSubview:[menuController view] belowSubview:controller.view];
-    
-    [manager orientSideMenuFromStatusBar];
-    
+        
     [[NSNotificationCenter defaultCenter] addObserver:manager
                                              selector:@selector(flipViewAccordingToStatusBarOrientation:)
                                                  name:UIApplicationDidChangeStatusBarOrientationNotification


### PR DESCRIPTION
Invoking `orientSideMenuFromStatusBar` in `-[MFSideMenuManager configureWithNavigationController:sideMenuController:menuSide:options:]` causes unwanted side effects when the side menu controller is a `UINavigationController`. In this situation, the frames of the top view controller's view and navigation bar are not set correctly. This was introduced in commit 7afb3dccaf39969a6f5956814ef2a95f5d218b9b.

I am not sure what the purpose of this invocation is, since everything works as expected in the sample project even when the invocation is missing.
