### PR TITLE
Add menu option to restore default back button

### DIFF
--- a/MFSideMenuDemo/MFSideMenu/MFSideMenu.h
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenu.h
@@ -19,7 +19,8 @@ typedef enum {
 typedef enum {
     MFSideMenuOptionMenuButtonEnabled = 1 << 0, // enable the 'menu' UIBarButtonItem
     MFSideMenuOptionBackButtonEnabled = 1 << 1, // enable the 'back' UIBarButtonItem
-    MFSideMenuOptionShadowEnabled = 1 << 2, // enable the shadow between the navigation controller & side menu
+    MFSideMenuOptionRestoreBackButton = 1 << 3, // restores the default 'back' UIBarButtonItem (only applies if MFSideMenuOptionBackButtonEnabled is set)
+    MFSideMenuOptionShadowEnabled = 1 << 2 // enable the shadow between the navigation controller & side menu
 } MFSideMenuOptions;
 
 typedef enum {
@@ -47,6 +48,7 @@ typedef void (^MFSideMenuStateEventBlock)(MFSideMenuStateEvent);
 @property (nonatomic, strong, readonly) UITableViewController *sideMenuController;
 @property (nonatomic, assign) MFSideMenuState menuState;
 @property (nonatomic, assign) MFSideMenuPanMode panMode;
+@property (nonatomic, strong) UIBarButtonItem *savedBackButtonItem;
 
 // this can be used to observe all MFSideMenuStateEvents
 @property (copy) MFSideMenuStateEventBlock menuStateEventBlock;

--- a/MFSideMenuDemo/MFSideMenu/MFSideMenu.m
+++ b/MFSideMenuDemo/MFSideMenu/MFSideMenu.m
@@ -194,6 +194,10 @@
     return ((self.options & MFSideMenuOptionBackButtonEnabled) == MFSideMenuOptionBackButtonEnabled);
 }
 
+- (BOOL) restoreBackButton {
+    return ((self.options & MFSideMenuOptionRestoreBackButton) == MFSideMenuOptionRestoreBackButton);
+}
+
 - (BOOL) shadowEnabled {
     return ((self.options & MFSideMenuOptionShadowEnabled) == MFSideMenuOptionShadowEnabled);
 }
@@ -235,6 +239,10 @@
             navigationItem.rightBarButtonItem = [self menuBarButtonItem];
         } else if(self.menuSide == MFSideMenuLocationLeft &&
                   (self.menuState == MFSideMenuStateVisible || self.navigationController.viewControllers.count == 1)) {
+            if ([self restoreBackButton]) {
+                self.savedBackButtonItem = navigationItem.leftBarButtonItem;
+            }
+            
             // show the menu button on the root view controller or if the menu is open
             navigationItem.leftBarButtonItem = [self menuBarButtonItem];
         }
@@ -242,7 +250,11 @@
     
     if([self backButtonEnabled] && self.navigationController.viewControllers.count > 1
        && self.menuState == MFSideMenuStateHidden) {
-        navigationItem.leftBarButtonItem = [self backBarButtonItem];
+        if ([self restoreBackButton]) {
+            navigationItem.leftBarButtonItem = self.savedBackButtonItem;
+        } else {
+            navigationItem.leftBarButtonItem = [self backBarButtonItem];
+        }
     }
 }
 


### PR DESCRIPTION
Using the default options, if you show and hide the side menu from a pushed view controller (using a pan), it replaces the back button with an arrow. I wanted it to restore the default back button (with the title of the previous view controller), so I added this option.
