### PR TITLE
fix for issue 54 - panning doesn't work correctly with one menu

### DIFF
--- a/MFSideMenu/MFSideMenu.m
+++ b/MFSideMenu/MFSideMenu.m
@@ -274,8 +274,10 @@ typedef enum {
     }
 }
 
+// -- handleRightPan has been modified to fix issue 54 --
+
 - (void) handleRightPan:(UIPanGestureRecognizer *)recognizer {
-    if(!self.leftSideMenuViewController) return;
+//  if(!self.leftSideMenuViewController) return;                        // remove this line to fix issue 54 - ensure panning to right works in all cases
     
     UIView *view = self.rootViewController.view;
     
@@ -290,6 +292,7 @@ typedef enum {
         translatedPoint.x = MIN(translatedPoint.x, 0);
     } else {
         // we are opening the menu
+        if(!self.leftSideMenuViewController) return;                    // add this line to fix issue 54 - ensure panning to right works in all cases
         translatedPoint.x = MAX(translatedPoint.x, 0);
     }
     
@@ -328,8 +331,10 @@ typedef enum {
 	}
 }
 
+// -- handleLeftPan has been modified to fix issue 54 --
+
 - (void) handleLeftPan:(UIPanGestureRecognizer *)recognizer {
-    if(!self.rightSideMenuViewController) return;
+//  if(!self.rightSideMenuViewController) return;                   // remove this line to fix issue 54 - ensure panning to left works in all cases
     
     UIView *view = self.rootViewController.view;
     
@@ -344,6 +349,7 @@ typedef enum {
         translatedPoint.x = MAX(translatedPoint.x, 0);
     } else {
         // we are opening the menu
+        if(!self.rightSideMenuViewController) return;                   // add this line to fix issue 54 - ensure panning to left works in all cases
         translatedPoint.x = MIN(translatedPoint.x, 0);
     }
     
@@ -441,8 +447,11 @@ typedef enum {
 #pragma mark -
 #pragma mark - Menu Rotation
 
+// -- as part of fix 54 - a fix for the "dead store" analyzer warning is included below --
+
 - (void) orientSideMenuFromStatusBar {
-    CGRect newFrame = self.rootViewController.view.window.bounds;
+//  CGRect newFrame = self.rootViewController.view.window.bounds;                       // this line is flagged by the analyzer as a "dead store"
+    CGRect newFrame;                                                                    // create the variable here without initialization
     newFrame = self.rootViewController.view.window.screen.applicationFrame;
     self.menuContainerView.transform = self.navigationController.view.transform;
     self.menuContainerView.frame = newFrame;


### PR DESCRIPTION
There are 2 fixes in this request:

1 - Simple fixes to handleLeftPan & handleRightPan to fix panning when the appropriate view controller is set to nil.

2 - In orientSideMenuFromStatusBar, the analyzer reports a "dead store" warning.  This two line fix eliminates the only analyzer warning in the project.
