### PR TITLE
assign for an object breaks ARC

### DIFF
--- a/MFSideMenu/MFSideMenu.h
+++ b/MFSideMenu/MFSideMenu.h
@@ -40,7 +40,7 @@ typedef void (^MFSideMenuStateEventBlock)(MFSideMenuStateEvent);
 @property (nonatomic, assign) CGFloat menuWidth; // size of the side menu(s)
 @property (nonatomic, assign) CGFloat shadowRadius; // radius of the shadow
 @property (nonatomic, assign) CGFloat shadowOpacity;
-@property (nonatomic, assign) UIColor *shadowColor;
+@property (nonatomic, strong) UIColor *shadowColor;
 
 // this can be used to observe all MFSideMenuStateEvents
 @property (copy) MFSideMenuStateEventBlock menuStateEventBlock;


### PR DESCRIPTION
setting assign rather than strong causes ARC to ditch the memory allocated for the shadowColor before it's used. 
