### PR TITLE
Fixed the panning slide animation so that it behaves the same as using the toggle action

### DIFF
--- a/Demos/MFSideMenuDemoBasic/MFSideMenuDemoBasic/DemoViewController.m
+++ b/Demos/MFSideMenuDemoBasic/MFSideMenuDemoBasic/DemoViewController.m
@@ -18,7 +18,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     if(!self.title) self.title = @"Demo!";
-    
+    [self.menuContainerViewController setPanMode:MFsideMenuPanModePanWhenOpen];
     [self setupMenuBarButtonItems];
 }
 

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -14,7 +14,8 @@ typedef enum {
     MFSideMenuPanModeNone = 0, // pan disabled
     MFSideMenuPanModeCenterViewController = 1 << 0, // enable panning on the centerViewController
     MFSideMenuPanModeSideMenu = 1 << 1, // enable panning on side menus
-    MFSideMenuPanModeDefault = MFSideMenuPanModeCenterViewController | MFSideMenuPanModeSideMenu
+    MFSideMenuPanModeDefault = MFSideMenuPanModeCenterViewController | MFSideMenuPanModeSideMenu,
+    MFsideMenuPanModePanWhenOpen // enable panning on center view when open
 } MFSideMenuPanMode;
 
 typedef enum {

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -46,6 +46,7 @@ typedef enum {
 @property (nonatomic, assign) MFSideMenuPanMode panMode;
 
 // menu open/close animation duration -- user can pan faster than default duration, max duration sets the limit
+@property (nonatomic, assign) BOOL menuAnimationAutoDurationEnabled;
 @property (nonatomic, assign) CGFloat menuAnimationDefaultDuration;
 @property (nonatomic, assign) CGFloat menuAnimationMaxDuration;
 

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -72,3 +72,12 @@ typedef enum {
 - (void)setRightMenuWidth:(CGFloat)rightMenuWidth animated:(BOOL)animated;
 
 @end
+
+// category on UIViewController to provide access to the viewDeckController in the
+// contained viewcontrollers, a la UINavigationController.
+@interface UIViewController (MFSideMenuAdditions)
+
+@property(nonatomic,readonly,retain) MFSideMenuContainerViewController *menuContainerViewController;
+
+@end
+

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -745,8 +745,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     id containerView = self.navigationController.parentViewController;
     if ([containerView isKindOfClass:[MFSideMenuContainerViewController class]])
         return containerView;
-    else
-        return nil;
+    return nil;
 }
 
 @end

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -734,5 +734,19 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     return MIN(duration, self.menuAnimationMaxDuration);
 }
 
+@end
+
+
+@implementation UIViewController (MFSideMenuAdditions)
+
+@dynamic menuContainerViewController;
+
+- (MFSideMenuContainerViewController *)menuContainerViewController {
+    id containerView = self.navigationController.parentViewController;
+    if ([containerView isKindOfClass:[MFSideMenuContainerViewController class]])
+        return containerView;
+    else
+        return nil;
+}
 
 @end

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -469,6 +469,11 @@ typedef enum {
 #pragma mark - MFSideMenuPanMode
 
 - (BOOL) centerViewControllerPanEnabled {
+    if (self.panMode & MFsideMenuPanModePanWhenOpen) {
+        if ((self.menuState & MFSideMenuStateLeftMenuOpen) || (self.menuState & MFSideMenuStateRightMenuOpen)) {
+            return YES;
+        }
+    }
     return ((self.panMode & MFSideMenuPanModeCenterViewController) == MFSideMenuPanModeCenterViewController);
 }
 

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -44,6 +44,7 @@ typedef enum {
 @synthesize shadowOpacity = _shadowOpacity;
 @synthesize menuSlideAnimationEnabled;
 @synthesize menuSlideAnimationFactor;
+@synthesize menuAnimationAutoDurationEnabled;
 @synthesize menuAnimationDefaultDuration;
 @synthesize menuAnimationMaxDuration;
 
@@ -89,6 +90,7 @@ typedef enum {
     self.menuAnimationDefaultDuration = 0.2f;
     self.menuAnimationMaxDuration = 0.4f;
     self.panMode = MFSideMenuPanModeDefault;
+    self.menuAnimationAutoDurationEnabled = YES;
 }
 
 - (void)setupMenuContainerView {
@@ -725,7 +727,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     CGFloat animationPositionDelta = ABS(endPosition - startPosition);
     
     CGFloat duration;
-    if(ABS(self.panGestureVelocity) > 1.0) {
+    if(ABS(self.panGestureVelocity && self.menuAnimationAutoDurationEnabled) > 1.0) {
         // try to continue the animation at the speed the user was swiping
         duration = animationPositionDelta / ABS(self.panGestureVelocity);
     } else {

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -352,16 +352,16 @@ typedef enum {
 - (void)alignLeftMenuControllerWithCenterViewController {
     CGRect leftMenuFrame = [self.leftMenuViewController view].frame;
     leftMenuFrame.size.width = _leftMenuWidth;
-    CGFloat menuX = [self.centerViewController view].frame.origin.x - leftMenuFrame.size.width;
-    leftMenuFrame.origin.x = menuX;
+    CGFloat xOffset = [self.centerViewController view].frame.origin.x;
+    leftMenuFrame.origin.x = xOffset / self.menuSlideAnimationFactor - _leftMenuWidth / self.menuSlideAnimationFactor;
     [self.leftMenuViewController view].frame = leftMenuFrame;
 }
 
 - (void)alignRightMenuControllerWithCenterViewController {
     CGRect rightMenuFrame = [self.rightMenuViewController view].frame;
     rightMenuFrame.size.width = _rightMenuWidth;
-    CGFloat menuX = [self.centerViewController view].frame.size.width + [self.centerViewController view].frame.origin.x;
-    rightMenuFrame.origin.x = menuX;
+    CGFloat xOffset = [self.centerViewController view].frame.origin.x;
+    rightMenuFrame.origin.x = [self.centerViewController view].frame.size.width - _rightMenuWidth + xOffset / self.menuSlideAnimationFactor + _rightMenuWidth / self.menuSlideAnimationFactor;
     [self.rightMenuViewController view].frame = rightMenuFrame;
 }
 
@@ -704,7 +704,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     }
 }
 
-- (void) setCenterViewControllerOffset:(CGFloat)xOffset {
+- (void)setCenterViewControllerOffset:(CGFloat)xOffset {
     CGRect frame = [self.centerViewController view].frame;
     frame.origin.x = xOffset;
     [self.centerViewController view].frame = frame;


### PR DESCRIPTION
Currently when menuSlideAnimation is enabled, the panning behavior for the left and right view controllers is different than the behavior when using the toggle open/close animation.  This pull request aligns the two behaviors just like in the Wunderlist 2 application by using menuAnimationSlideFactor when aligning the left and right view controllers with the centerViewController offset.
