### PR TITLE
Fixes the menu sliding animation when user pans

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -350,16 +350,16 @@ typedef enum {
 - (void)alignLeftMenuControllerWithCenterViewController {
     CGRect leftMenuFrame = [self.leftMenuViewController view].frame;
     leftMenuFrame.size.width = _leftMenuWidth;
-    CGFloat menuX = [self.centerViewController view].frame.origin.x - leftMenuFrame.size.width;
-    leftMenuFrame.origin.x = menuX;
+    CGFloat xOffset = [self.centerViewController view].frame.origin.x;
+    leftMenuFrame.origin.x = xOffset / self.menuSlideAnimationFactor - _leftMenuWidth / self.menuSlideAnimationFactor;
     [self.leftMenuViewController view].frame = leftMenuFrame;
 }
 
 - (void)alignRightMenuControllerWithCenterViewController {
     CGRect rightMenuFrame = [self.rightMenuViewController view].frame;
     rightMenuFrame.size.width = _rightMenuWidth;
-    CGFloat menuX = [self.centerViewController view].frame.size.width + [self.centerViewController view].frame.origin.x;
-    rightMenuFrame.origin.x = menuX;
+    CGFloat xOffset = [self.centerViewController view].frame.origin.x;
+    rightMenuFrame.origin.x = [self.centerViewController view].frame.size.width - _rightMenuWidth + xOffset / self.menuSlideAnimationFactor + _rightMenuWidth / self.menuSlideAnimationFactor;
     [self.rightMenuViewController view].frame = rightMenuFrame;
 }
 


### PR DESCRIPTION
Currently when menuSliderAnimation is enabled, the behavior the user encounters when panning is different from the behavior when the user uses the toggle button.  This change aligns the two behaviors by using the menuSlideAnimationFactor when calculating the position of the left and right view controllers.  This behavior will make the menuSlideAnimation the same as Wunderlist 2 app. 
