### PR TITLE
Updated readme, added boolean to disable auto duration based on user swipe

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -45,6 +45,7 @@ typedef enum {
 @property (nonatomic, assign) MFSideMenuPanMode panMode;
 
 // menu open/close animation duration -- user can pan faster than default duration, max duration sets the limit
+@property (nonatomic, assign) BOOL menuAnimationAutoDurationEnabled;
 @property (nonatomic, assign) CGFloat menuAnimationDefaultDuration;
 @property (nonatomic, assign) CGFloat menuAnimationMaxDuration;
 

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -46,6 +46,7 @@ typedef enum {
 @synthesize shadowOpacity = _shadowOpacity;
 @synthesize menuSlideAnimationEnabled;
 @synthesize menuSlideAnimationFactor;
+@synthesize menuAnimationAutoDurationEnabled;
 @synthesize menuAnimationDefaultDuration;
 @synthesize menuAnimationMaxDuration;
 
@@ -92,6 +93,7 @@ typedef enum {
     self.menuAnimationMaxDuration = 0.4f;
     self.panMode = MFSideMenuPanModeDefault;
     self.viewHasAppeared = NO;
+    self.menuAnimationAutoDurationEnabled = YES;
 }
 
 - (void)setupMenuContainerView {
@@ -793,7 +795,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     CGFloat animationPositionDelta = ABS(endPosition - startPosition);
     
     CGFloat duration;
-    if(ABS(self.panGestureVelocity) > 1.0) {
+    if(ABS(self.panGestureVelocity) > 1.0 && self.menuAnimationAutoDurationEnabled) {
         // try to continue the animation at the speed the user was swiping
         duration = animationPositionDelta / ABS(self.panGestureVelocity);
     } else {

--- a/README.mdown
+++ b/README.mdown
@@ -43,6 +43,16 @@ self.window.rootViewController = container;
 [self.window makeKeyAndVisible];
 ```
 
+###Animation Speed
+By default, the animation duration is set to how fast the user was swiping. The user can pan faster than the default duration and the max duration sets the limit.
+```objective-c
+[self.menuContainerViewController setMenuAnimationDefaultDuration:0.3f];
+[self.menuContainerViewController setMenuAnimationMaxDuration:0.4f];
+
+// disable this behavior
+[self.menuContainerViewController setMenuAnimationAutoDurationEnabled:NO];
+```
+
 ###Opening & Closing Menus
 
 ```objective-c


### PR DESCRIPTION
Added the ability to disable the default behavior of adjusting the animation duration based on user panning.  When menuAnimationAutoDurationEnabled is set to false, the default animation duration is always used.
