### PR TITLE
Reset panGestureVelocity after user finishes swiping

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -743,6 +743,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     if(ABS(self.panGestureVelocity) > 1.0) {
         // try to continue the animation at the speed the user was swiping
         duration = animationPositionDelta / ABS(self.panGestureVelocity);
+        self.panGestureVelocity = 0.0;
     } else {
         // no swipe was used, user tapped the bar button item
         // TODO: full animation duration hard to calculate with two menu widths


### PR DESCRIPTION
Currently the panGestureVelocity does not get reset after the user finishes performing the swipe behavior. This causes the animation duration to be calculated as a factor of the panGestureVelocity even when no swipe was used (ie. user tapped bar button item).
