### PR TITLE
Added more options for sliding operation

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -54,12 +54,30 @@ typedef enum {
 @property (nonatomic, assign) CGFloat leftMenuWidth;
 @property (nonatomic, assign) CGFloat rightMenuWidth;
 
-// shadow
-@property (nonatomic, strong) MFSideMenuShadow *shadow;
+// shadows - content shadow only shown when showMenuOverContent = NO
+//         - menu shadows only shown when showMenuOverContent = YES
+@property (nonatomic, strong) MFSideMenuShadow *contentShadow;
+@property (nonatomic, strong) MFSideMenuShadow *leftMenuShadow;
+@property (nonatomic, strong) MFSideMenuShadow *rightMenuShadow;
+
+// menu depth
+@property (nonatomic, assign) BOOL showMenuOverContent;
 
 // menu slide-in animation
-@property (nonatomic, assign) BOOL menuSlideAnimationEnabled;
-@property (nonatomic, assign) CGFloat menuSlideAnimationFactor; // higher = less menu movement on animation
+@property (nonatomic, assign) CGFloat menuParallaxFactor;
+// 0 = no menu movement
+// > 0 & < 1 = ratio of movement to menu width
+// 1 = full menu movement
+
+// content slide-out animation
+@property (nonatomic, assign) CGFloat contentParallaxFactor;
+// 0 = no menu movement
+// > 0 & < 1 = ratio of movement to menu width
+// 1 = full menu movement
+
+
+@property (nonatomic, assign) BOOL menuSlideAnimationEnabled __deprecated;
+@property (nonatomic, assign) CGFloat menuSlideAnimationFactor __deprecated; // higher = less menu movement on animation
 
 
 - (void)toggleLeftSideMenuCompletion:(void (^)(void))completion;

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -60,25 +60,34 @@ typedef enum {
 @property (nonatomic, strong) MFSideMenuShadow *leftMenuShadow;
 @property (nonatomic, strong) MFSideMenuShadow *rightMenuShadow;
 
+// depreciated sliding properties - replace with options below
+@property (nonatomic, assign) BOOL menuSlideAnimationEnabled __deprecated;
+@property (nonatomic, assign) CGFloat menuSlideAnimationFactor __deprecated; // higher = less menu movement on animation
+
 // menu depth
 @property (nonatomic, assign) BOOL showMenuOverContent;
 
 // menu slide-in animation
 @property (nonatomic, assign) CGFloat menuParallaxFactor;
-// 0 = no menu movement
+// 0 = no menu movement (default)
 // > 0 & < 1 = ratio of movement to menu width
 // 1 = full menu movement
 
 // content slide-out animation
 @property (nonatomic, assign) CGFloat contentParallaxFactor;
-// 0 = no menu movement
+// 0 = no menu movement (default)
 // > 0 & < 1 = ratio of movement to menu width
 // 1 = full menu movement
 
+// menu slide in scaling
+@property (nonatomic, assign) CGFloat menuScaleFactor;
+// 1 = no scaling (default)
+// < 1 = scale of menu at close
 
-@property (nonatomic, assign) BOOL menuSlideAnimationEnabled __deprecated;
-@property (nonatomic, assign) CGFloat menuSlideAnimationFactor __deprecated; // higher = less menu movement on animation
-
+// content slide out scaling
+@property (nonatomic, assign) CGFloat contentScaleFactor;
+// 1 = no scaling (default)
+// < 1 = scale of content at menu open
 
 - (void)toggleLeftSideMenuCompletion:(void (^)(void))completion;
 - (void)toggleRightSideMenuCompletion:(void (^)(void))completion;

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -269,19 +269,25 @@ typedef enum {
 
 - (void)addGestureRecognizers {
     [self addCenterGestureRecognizers];
-    [self.view addGestureRecognizer:[self panGestureRecognizer]];
+    [self.leftMenuContainer addGestureRecognizer:[self panGestureRecognizer]];
+    [self.rightMenuContainer addGestureRecognizer:[self panGestureRecognizer]];
 }
 
 - (void)removeCenterGestureRecognizers
 {
     if (self.centerViewController)
+    {
         [[self.centerViewController view] removeGestureRecognizer:[self centerTapGestureRecognizer]];
+        [[self.centerViewController view] removeGestureRecognizer:[self panGestureRecognizer]];
+    }
 }
-
 - (void)addCenterGestureRecognizers
 {
     if (self.centerViewController)
+    {
         [[self.centerViewController view] addGestureRecognizer:[self centerTapGestureRecognizer]];
+        [[self.centerViewController view] addGestureRecognizer:[self panGestureRecognizer]];
+    }
 }
 
 - (UITapGestureRecognizer *)centerTapGestureRecognizer
@@ -424,9 +430,9 @@ typedef enum {
             [self setControllerOffset:offset];
             
             // Otherwise shadow is removed while menu closes
-            if (self.leftMenuShadow.alpha != leftAlpha && leftAlpha == 1.0)
+            if (self.leftMenuShadow.alpha != leftAlpha && leftAlpha > 0)
                 self.leftMenuShadow.alpha = leftAlpha;
-            if (self.rightMenuShadow.alpha != rightAlpha && rightAlpha == 1.0)
+            if (self.rightMenuShadow.alpha != rightAlpha && rightAlpha > 0)
                 self.rightMenuShadow.alpha = rightAlpha;
             
             if(additionalAnimations) additionalAnimations();
@@ -527,9 +533,11 @@ typedef enum {
         return;
     }
     
-    CGFloat offset = _leftMenuWidth;
+    CGRect menuRect = self.leftMenuContainer.frame;
+    menuRect.size.width = _leftMenuWidth;
+    self.leftMenuContainer.frame = menuRect;
     
-    [self setControllerOffset:offset animated:animated completion:nil];
+    [self setControllerOffset:_leftMenuWidth animated:animated completion:nil];
 }
 
 - (void)setRightMenuWidth:(CGFloat)rightMenuWidth animated:(BOOL)animated {
@@ -540,9 +548,12 @@ typedef enum {
         return;
     }
     
-    CGFloat offset = -rightMenuWidth;
+    CGRect menuRect = self.rightMenuContainer.frame;
+    menuRect.origin.x = self.view.bounds.size.width - _rightMenuWidth;
+    menuRect.size.width = _rightMenuWidth;
+    self.rightMenuContainer.frame = menuRect;
     
-    [self setControllerOffset:offset animated:animated completion:nil];
+    [self setControllerOffset:-_rightMenuWidth animated:animated completion:nil];
 }
 
 

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -420,13 +420,13 @@ typedef enum {
                 self.leftImageView.image = nil;
                 self.leftImageView.hidden = YES;
                 self.leftMenuViewController.view.hidden = NO;
-                self.leftMenuShadow.shadowedView = self.leftMenuViewController.view;
+                self.leftMenuShadow.shadowedView = self.leftMenuContainer;
                 [self.leftMenuShadow draw];
                 
                 self.rightImageView.image = nil;
                 self.rightImageView.hidden = YES;
                 self.rightMenuViewController.view.hidden = NO;
-                self.rightMenuShadow.shadowedView = self.rightMenuViewController.view;
+                self.rightMenuShadow.shadowedView = self.rightMenuContainer;
                 [self.rightMenuShadow draw];
                 
                 innerCompletion();
@@ -441,7 +441,7 @@ typedef enum {
                 self.leftImageView.image = nil;
                 self.leftImageView.hidden = YES;
                 self.leftMenuViewController.view.hidden = NO;
-                self.leftMenuShadow.shadowedView = self.leftMenuViewController.view;
+                self.leftMenuShadow.shadowedView = self.leftMenuContainer;
                 [self.leftMenuShadow draw];
                 innerCompletion();
             }];
@@ -455,7 +455,7 @@ typedef enum {
                 self.rightImageView.image = nil;
                 self.rightImageView.hidden = YES;
                 self.rightMenuViewController.view.hidden = NO;
-                self.rightMenuShadow.shadowedView = self.rightMenuViewController.view;
+                self.rightMenuShadow.shadowedView = self.rightMenuContainer;
                 [self.rightMenuShadow draw];
                 innerCompletion();
             }];

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -454,7 +454,7 @@ typedef enum {
     
     leftFrame.origin.x = MIN(0, MAX(-self.leftMenuWidth, offset - self.leftMenuWidth)) * self.menuParallaxFactor;
     centerFrame.origin.x = offset * self.contentParallaxFactor;
-    rightFrame.origin.x = self.view.bounds.size.width - self.rightMenuWidth * (1 - self.menuParallaxFactor) + offset * self.menuParallaxFactor;
+    rightFrame.origin.x = centerFrame.size.width - self.rightMenuWidth * (1 - self.menuParallaxFactor) + offset * self.menuParallaxFactor;
     
     self.leftMenuContainer.frame = leftFrame;
     [self.centerViewController view].frame = centerFrame;

--- a/MFSideMenu/MFSideMenuShadow.h
+++ b/MFSideMenu/MFSideMenuShadow.h
@@ -15,6 +15,7 @@
 @property (nonatomic, assign) CGFloat opacity;
 @property (nonatomic, strong) UIColor *color;
 @property (nonatomic, assign) UIView *shadowedView;
+@property (nonatomic, assign) CGFloat alpha;
 
 + (MFSideMenuShadow *)shadowWithView:(UIView *)shadowedView;
 + (MFSideMenuShadow *)shadowWithColor:(UIColor *)color radius:(CGFloat)radius opacity:(CGFloat)opacity;

--- a/MFSideMenu/MFSideMenuShadow.m
+++ b/MFSideMenu/MFSideMenuShadow.m
@@ -16,6 +16,7 @@
 @synthesize radius = _radius;
 @synthesize enabled = _enabled;
 @synthesize shadowedView;
+@synthesize alpha = _alpha;
 
 + (MFSideMenuShadow *)shadowWithView:(UIView *)shadowedView {
     MFSideMenuShadow *shadow = [MFSideMenuShadow shadowWithColor:[UIColor blackColor] radius:10.0f opacity:0.75f];
@@ -38,6 +39,7 @@
         self.opacity = 0.75f;
         self.radius = 10.0f;
         self.enabled = YES;
+        self.alpha = 1.0;
     }
     return self;
 }
@@ -66,6 +68,10 @@
     [self draw];
 }
 
+- (void)setAlpha:(CGFloat)shadowAlpha {
+    _alpha = shadowAlpha;
+    [self draw];
+}
 
 #pragma mark -
 #pragma mark - Drawing
@@ -81,8 +87,9 @@
 - (void)show {
     CGRect pathRect = self.shadowedView.bounds;
     pathRect.size = self.shadowedView.frame.size;
+    self.shadowedView.layer.masksToBounds = NO;
     self.shadowedView.layer.shadowPath = [UIBezierPath bezierPathWithRect:pathRect].CGPath;
-    self.shadowedView.layer.shadowOpacity = self.opacity;
+    self.shadowedView.layer.shadowOpacity = self.opacity * self.alpha;
     self.shadowedView.layer.shadowRadius = self.radius;
     self.shadowedView.layer.shadowColor = [self.color CGColor];
     self.shadowedView.layer.rasterizationScale = [[UIScreen mainScreen] scale];

--- a/README.mdown
+++ b/README.mdown
@@ -97,34 +97,68 @@ You can listen for menu state event changes (i.e. menu will open, menu did open,
 }
 ```
 
-###Menu Slide Animation
+###Sliding Options
 
-With this option enabled, the side menus will slide in & out with the center view controller. This effect is similar to the Wunderlist side menu.
+Control how the center view and each menu slide.
 
 ```objective-c
-// enable the menu slide animation
-[menuContainerViewController setMenuSlideAnimationEnabled:YES];
+// keep menus behind center view (Default)
+[menuContainerViewController setShowMenuOverContent:NO];
 
-// control the exaggeration of the menu slide animation
-[menuContainerViewController setMenuSlideAnimationFactor:3.0f];
+// menu stationary (Default)
+[menuContainerViewController setMenuParallaxFactor:0.0f];
 ```
+![](http://i.imgur.com/1kEXXHV.png)
+```objective-c
+// menu slides half of the width
+[menuContainerViewController setMenuParallaxFactor:0.5f];
+```
+![](http://i.imgur.com/nAlFyiM.png)
+```objective-c
+// menu slides with center view
+[menuContainerViewController setMenuParallaxFactor:1.0f];
+```
+![](http://i.imgur.com/29BdgR5.png)
+```objective-c
+// bring menus in front of center view
+[menuContainerViewController setShowMenuOverContent:YES];
+
+// center view stationary (Default)
+[menuContainerViewController setContentParallaxFactor:0.0f];
+```
+![](http://i.imgur.com/tOZKJWV.png)
+```objective-c
+// center view slides half of the menu width
+[menuContainerViewController setContentParallaxFactor:0.5f];
+```
+![](http://i.imgur.com/i6siBOT.png)
+```objective-c
+// center view slides with menu
+[menuContainerViewController setMenuParallaxFactor:1.0f];
+```
+![](http://i.imgur.com/ayVtwF1.png)
+
 
 ###Shadow
 
 MFSideMenu gives you the option to show a shadow between the center view controller & the side menus.
 
+The `contentShadow` property is used for shadow of the center view controller over the side menus. It is only seen when `showMenuOverContent = NO`.
+
+The `leftMenuShadow` and `rightMenuShadow` properties are used for shadows of the side menus over the center view. They are only seen when `showMenuOverContent = YES`.
+
 ```objective-c
 // enable/disable the shadow
-[menuContainerViewController.shadow setEnabled:YES];
+[menuContainerViewController.contentShadow setEnabled:YES];
 
 // set the radius of the shadow
-[menuContainerViewController.shadow setRadius:10.0f];
+[menuContainerViewController.contentShadow setRadius:10.0f];
 
 // set the color of the shadow
-[menuContainerViewController.shadow setColor:[UIColor blackColor]];
+[menuContainerViewController.contentShadow setColor:[UIColor blackColor]];
 
 // set the opacity of the shadow
-[menuContainerViewController.shadow setOpacity:0.75f];
+[menuContainerViewController.contentShadow setOpacity:0.75f];
 
 ```
 


### PR DESCRIPTION
Wanted to add a few more options to the way the center view controller and side menus slide past one another. Here's a breakdown of what's different:
- Depreciated `menuSlideAnimationEnabled` and `menuSlideAnimationFactor` properties. They still work, but there will be some unclear results from mixing new and old properties, so they're marked as depreciated and will throw a warning if used.
- Created new internal method `setControllerOffset`. An offset of 0 means closed, negative would open the right menu, and positive would open the left menu. All three views are positioned from this view so that there is no need for methods aligning views to one another.
- Created `showMenuOverContent` property that allows the menus to slide in front of the center view controller. The default is still to slide behind the center.
- Created `menuParallaxFactor` property to control the amount of sliding of the side menus. A factor of 0 would leave the menu stationary (default behavior), a factor of 1 would slide the menu directly with the center (like a UIPageViewController), and a factor between 0 and 1 would slide the menu at a different speed from the center, giving it a parallax scrolling effect. This is only utilized when menus are behind the center view.
- Created `contentParallaxFactor` property to control the amount of sliding of the center view. The values go from 0 to 1 and work as described for the `menuParallaxFactor`. This is only utilized when menus are in front of the center view.
- Created `menuScaleFactor` property to control the size of the side menus as they slide in. For example, with a factor of 0.9, the side menu will be 90% of full size when sliding begins, then grow to fill the entire size when the menu is open. This is only utilized when menus are behind the center view.
- Created `contentScaleFactor` property to control the size of the center view as it slides out. For example, with a factor of 0.9, the center view will be full size when sliding begins, then shrink to 90% when the menu is open. This is only utilized when menus are in front of the center view.
- Created separate shadows for all three views. Shadows only show up on the view in front. When the menus are in front, their shadows gradually fade in and out when open/closed so there is no shadow when the menus aren't up.
- Remove the locking of directions (resolves #109). When closed, user can start panning right, and still pan left without having to begin a new gesture.

I realize that this is a pretty major change and that there is a lot of code that is being modified. Take a look through it and let me know what you think.

(Go Badgers!)
