### PR TITLE
Check whether the panning is horizontal before opening side menus

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -514,6 +514,12 @@ typedef enum {
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+        UIPanGestureRecognizer *panRecognizer = (UIPanGestureRecognizer *)gestureRecognizer;
+        CGPoint velocity = [panRecognizer velocityInView:gestureRecognizer.view];
+        bool isHorizontalPanning = fabsf(velocity.x) > fabsf(velocity.y);
+        return isHorizontalPanning;
+    }
     return YES;
 }
 


### PR DESCRIPTION
Hi Mike,

I have added a check in `gestureRecognizerShouldBegin:` whether the panning gesture is horizontal panning before handling it. I think it is useful in the case the main view controller has a scroll view, e.g UITableViewController, the panning up and down on the table won't open the side menus.

Again, thank you for your project =)

Cheers,
Thuy
