### PR TITLE
Adjust child scroll view insets for status bar

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -126,6 +126,21 @@ typedef enum {
     }
 }
 
+- (void)viewWillLayoutSubviews {
+    [super viewWillLayoutSubviews];
+    if ([self respondsToSelector:@selector(topLayoutGuide)]) {
+        if (_leftSideMenuViewController &&
+            [_leftSideMenuViewController automaticallyAdjustsScrollViewInsets] &&
+            [_leftSideMenuViewController.view respondsToSelector:@selector(setContentInset:)]) {
+            [(UIScrollView *)_leftSideMenuViewController.view setContentInset:UIEdgeInsetsMake([self.topLayoutGuide length], 0, 0, 0)];
+        }
+        if (_rightSideMenuViewController &&
+            [_rightSideMenuViewController automaticallyAdjustsScrollViewInsets] &&
+            [_rightSideMenuViewController.view respondsToSelector:@selector(setContentInset:)]) {
+            [(UIScrollView *)_rightSideMenuViewController.view setContentInset:UIEdgeInsetsMake([self.topLayoutGuide length], 0, 0, 0)];
+        }
+    }
+}
 
 #pragma mark -
 #pragma mark - UIViewController Rotation


### PR DESCRIPTION
Here's a non-hardcoded fix for the overlapping status bar bug on iOS 7 (#153), applicable when the side view(s) are `UIScrollView`s or `UITableView`s. It properly adjusts the inset when the status bar changes for an ongoing telephone call.

I'd prefer to just pass the `topLayoutGuide` down to the children, but it's `readonly`.
