### PR TITLE
Support PrefersStatusBarHidden for Top View Controller in the Center

### DIFF
--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -154,6 +154,16 @@ typedef enum {
     return UIStatusBarStyleDefault;
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+    if (self.centerViewController) {
+        if ([self.centerViewController isKindOfClass:[UINavigationController class]]) {
+            return [((UINavigationController *)self.centerViewController).topViewController prefersStatusBarHidden];
+        }
+        return [self.centerViewController prefersStatusBarHidden];
+    }
+    return NO;
+}
 
 #pragma mark -
 #pragma mark - UIViewController Rotation


### PR DESCRIPTION
Right now it is not possible to chose if you want the status bar to be
shown or not in the current top view controller and there may be cases where you want to have some of them with status bar and some without it.

With this change we will be able to override the function in the
topViewController and chose to hide/show the status bar.

By default we will display always the status bar
