### PR TITLE
Added support for disabling rotation based on the top view controller

### DIFF
--- a/MFSideMenu.podspec
+++ b/MFSideMenu.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'MFSideMenu'
-  s.version  = '0.5.5'
+  s.version  = '0.5.6'
   s.license  = 'BSD'
   s.summary  = 'Facebook-like side menu for iOS.'
   s.homepage = 'https://github.com/mikefrederick/MFSideMenu'

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -61,6 +61,8 @@ typedef enum {
 @property (nonatomic, assign) BOOL menuSlideAnimationEnabled;
 @property (nonatomic, assign) CGFloat menuSlideAnimationFactor; // higher = less menu movement on animation
 
+// rotation based on UINavigationController
+@property (nonatomic, assign) BOOL rotationBasedOnTopViewController; // default YES. If YES, the top view controller defines interface orientations. Otherwise, the navigation controller should do it.
 
 - (void)toggleLeftSideMenuCompletion:(void (^)(void))completion;
 - (void)toggleRightSideMenuCompletion:(void (^)(void))completion;

--- a/MFSideMenu/MFSideMenuContainerViewController.h
+++ b/MFSideMenu/MFSideMenuContainerViewController.h
@@ -61,8 +61,9 @@ typedef enum {
 @property (nonatomic, assign) BOOL menuSlideAnimationEnabled;
 @property (nonatomic, assign) CGFloat menuSlideAnimationFactor; // higher = less menu movement on animation
 
-// rotation based on UINavigationController
+// UINavigationController-specific tweaks
 @property (nonatomic, assign) BOOL rotationBasedOnTopViewController; // default YES. If YES, the top view controller defines interface orientations. Otherwise, the navigation controller should do it.
+@property (nonatomic, assign) BOOL statusBarStyleBasedOnTopViewController; // default YES. If YES, the top view controller defines status bar style. Otherwise, the navigation controller should do it.
 
 - (void)toggleLeftSideMenuCompletion:(void (^)(void))completion;
 - (void)toggleRightSideMenuCompletion:(void (^)(void))completion;

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -85,6 +85,7 @@ typedef enum {
     self.menuAnimationMaxDuration = 0.4f;
     self.panMode = MFSideMenuPanModeDefault;
     self.viewHasAppeared = NO;
+    self.rotationBasedOnTopViewController = YES;
 }
 
 - (void)setupMenuContainerView {
@@ -160,7 +161,7 @@ typedef enum {
 
 -(NSUInteger)supportedInterfaceOrientations {
     if (self.centerViewController) {
-        if ([self.centerViewController isKindOfClass:[UINavigationController class]]) {
+        if ([self.centerViewController isKindOfClass:[UINavigationController class]] && self.rotationBasedOnTopViewController) {
             return [((UINavigationController *)self.centerViewController).topViewController supportedInterfaceOrientations];
         }
         return [self.centerViewController supportedInterfaceOrientations];
@@ -170,7 +171,7 @@ typedef enum {
 
 -(BOOL)shouldAutorotate {
     if (self.centerViewController) {
-        if ([self.centerViewController isKindOfClass:[UINavigationController class]]) {
+        if ([self.centerViewController isKindOfClass:[UINavigationController class]] && self.rotationBasedOnTopViewController) {
             return [((UINavigationController *)self.centerViewController).topViewController shouldAutorotate];
         }
         return [self.centerViewController shouldAutorotate];
@@ -180,7 +181,7 @@ typedef enum {
 
 - (UIInterfaceOrientation)preferredInterfaceOrientationForPresentation {
     if (self.centerViewController) {
-        if ([self.centerViewController isKindOfClass:[UINavigationController class]]) {
+        if ([self.centerViewController isKindOfClass:[UINavigationController class]] && self.rotationBasedOnTopViewController) {
             return [((UINavigationController *)self.centerViewController).topViewController preferredInterfaceOrientationForPresentation];
         }
         return [self.centerViewController preferredInterfaceOrientationForPresentation];

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -86,6 +86,7 @@ typedef enum {
     self.panMode = MFSideMenuPanModeDefault;
     self.viewHasAppeared = NO;
     self.rotationBasedOnTopViewController = YES;
+    self.statusBarStyleBasedOnTopViewController = YES;
 }
 
 - (void)setupMenuContainerView {
@@ -147,7 +148,7 @@ typedef enum {
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
     if (self.centerViewController) {
-        if ([self.centerViewController isKindOfClass:[UINavigationController class]]) {
+        if ([self.centerViewController isKindOfClass:[UINavigationController class]] && self.statusBarStyleBasedOnTopViewController) {
             return [((UINavigationController *)self.centerViewController).topViewController preferredStatusBarStyle];
         }
         return [self.centerViewController preferredStatusBarStyle];

--- a/MFSideMenu/MFSideMenuContainerViewController.m
+++ b/MFSideMenu/MFSideMenuContainerViewController.m
@@ -160,7 +160,7 @@ typedef enum {
 #pragma mark -
 #pragma mark - UIViewController Rotation
 
--(NSUInteger)supportedInterfaceOrientations {
+-(UIInterfaceOrientationMask)supportedInterfaceOrientations {
     if (self.centerViewController) {
         if ([self.centerViewController isKindOfClass:[UINavigationController class]] && self.rotationBasedOnTopViewController) {
             return [((UINavigationController *)self.centerViewController).topViewController supportedInterfaceOrientations];
@@ -549,7 +549,7 @@ typedef enum {
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
     if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
         CGPoint velocity = [(UIPanGestureRecognizer *)gestureRecognizer velocityInView:gestureRecognizer.view];
-        BOOL isHorizontalPanning = fabsf(velocity.x) > fabsf(velocity.y);
+        BOOL isHorizontalPanning = fabs(velocity.x) > fabs(velocity.y);
         return isHorizontalPanning;
     }
     return YES;


### PR DESCRIPTION
Added a BOOL property that determines if the rotation methods result should be taken from the top view controller of a navigation controller (in the case of a UINavigationController being the centerViewController) or from the navigation controller itself.

This is useful for subclassing a UINavigationController and controlling the rotation from the superclass globally.

The default value is YES, so the default behavior matches the current implementation (using the top view controller by default).

Also added the same kind of BOOL but for the status bar style.